### PR TITLE
Use the Road Authority ID (RAID) to complement the Road Regulator ID

### DIFF
--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/css/switch.css
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/css/switch.css
@@ -1,0 +1,60 @@
+
+.onoffswitch {
+    position: relative; width: 50px;
+    -webkit-user-select:none; -moz-user-select:none; -ms-user-select: none;
+}
+
+.onoffswitch-checkbox {
+    display: none;
+}
+
+.onoffswitch-label {
+    display: block; overflow: hidden; cursor: pointer;
+    border: 2px solid #999999; border-radius: 5px;
+}
+
+.onoffswitch-inner {
+    display: block; width: 200%; margin-left: -100%;
+    -moz-transition: margin 0.3s ease-in 0s; -webkit-transition: margin 0.3s ease-in 0s;
+    -o-transition: margin 0.3s ease-in 0s; transition: margin 0.3s ease-in 0s;
+}
+
+.onoffswitch-inner:before, .onoffswitch-inner:after {
+    display: block; float: left; width: 50%; height: 20px; padding: 0; line-height: 25px;
+    font-size: 14px; color: white; font-family: Trebuchet, Arial, sans-serif; font-weight: bold;
+    -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box;
+}
+
+.onoffswitch-inner:before {
+    content: "YES";
+    padding-left: 0px;
+    background-color: #2aabd2; color: #FFFFFF;
+}
+
+.onoffswitch-inner:after {
+    content: "NO";
+    padding-right:5px;
+    background-color: #EEEEEE; color: #999999;
+    text-align: right;
+}
+
+.onoffswitch-switch {
+    display: block; width: 18px; margin: 0px;
+    background: #FFFFFF;
+    border: 2px solid #999999; border-radius: 5px;
+    position: absolute; top: 0; bottom: 0; right: 32px;
+    -moz-transition: all 0.3s ease-in 0s; -webkit-transition: all 0.3s ease-in 0s;
+    -o-transition: all 0.3s ease-in 0s; transition: all 0.3s ease-in 0s; 
+    background-image: -moz-linear-gradient(center top, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0) 100%);
+    background-image: -webkit-linear-gradient(center top, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0) 100%);
+    background-image: -o-linear-gradient(center top, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0) 100%);
+    background-image: linear-gradient(center top, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0) 100%);
+}
+
+.onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-inner {
+    margin-left: 0;
+}
+
+.onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-switch {
+    right: 0px; 
+}

--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/index.html
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/index.html
@@ -397,7 +397,7 @@
 							</div>
 							<div class="row region">
 								<div class="col-sm-4"><label for="region">Region ID:</label></div>
-								<div class="col-sm-7"><input class="form-control" id="region" placeholder="0 to 65535" data-parsley-pattern="^[0-9]+$" data-parsley-range="[0, 65535]" data-parsley-pattern-message="This value must be an integer."></div>
+                                                                <div class="col-sm-7"><input class="form-control" id="region" placeholder="0 to 65535" onchange="onRegionIdChangeCallback(this.value);" data-parsley-pattern="^[0-9]+$" data-parsley-range="[0, 65535]" data-parsley-pattern-message="This value must be an integer."></div>
 								<div class="col-sm-1"><i class="fa fa-question-circle" aria-hidden="true" tag="region_id"></i></div>
 							</div>
 							<div class="row intersection">
@@ -414,6 +414,17 @@
 								<div class="col-sm-4"><label for="major_version">Minor Version:</label></div>
 								<div class="col-sm-7"><input class="form-control extra_rga_field_input required" id="minor_version" placeholder="0 to 64" data-parsley-pattern="^[0-9]+$" data-parsley-range="[0, 64]" data-parsley-pattern-message="This value must be an integer."></div>
 								<div class="col-sm-1"><i class="fa fa-question-circle" aria-hidden="true" tag="minor_version"></i></div>
+							</div>
+							<div class="row road_authority_id_type">
+								<div class="col-sm-4"><label for="road_authority_id_type">Road Authority ID Type:</label></div>
+								<div class="col-sm-7">
+									<select name="road_authority_id_type" class="form-control" onchange="onRoadAuthorityIdTypeChangeCallback(this.value)" id = "road_authority_id_type">
+										<option value="full">Full</option>
+										<option value="relative">Relative</option>
+										<option value="">NA</option>
+									</select>
+								</div>
+								<div class="col-sm-1"><i class="fa fa-question-circle" aria-hidden="true" tag="road_authority_id_type"></i></div>
 							</div>
 							<div class="row road_authority_id">
 								<div class="col-sm-4"><label for="road_authority_id">Road Authority ID:</label></div>

--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/config.js
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/config.js
@@ -414,13 +414,21 @@ var help_notes = [
 		units: "N/A",
 		description: "It indicates that the dataset has changed but still compatible with prior versions of the dataset."
 	},
+        {
+		value: "road_authority_id_type",
+		title: "Road Authority Identifier Type",
+		max: "NA",
+		min: "NA",
+		units: "N/A",
+		description: "This Road Authority Identifier Type indicates whether the Road Authority ID is full or relative. If no type specified and region id is not zero, Road Authority ID is optional."
+	},
 	{
 		value: "road_authority_id",
 		title: "Road Authority Identifier",
 		max: "NA",
 		min: "NA",
 		units: "N/A",
-		description: "This data frame defines the Object Identifier (OID) of the Road Authority."
+		description: "This data frame defines the Object Identifier (OID) of the Road Authority. Road authority ID is mandatory if region id (roadRegulatoryID) is set to 0."
 	},
 	{
 		value: "mapped_geometry_id",

--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/depositor.js
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/depositor.js
@@ -404,6 +404,7 @@ function createMessageJSON()
                 "referenceLon": feature.attributes.LonLat.lon,
                 "referenceElevation": feature.attributes.elevation,
                 "roadAuthorityId": feature.attributes.roadAuthorityId,
+                "roadAuthorityIdType": feature.attributes.roadAuthorityIdType,
             };
 
             var data_frame_rga_base_layer_fields = {} //Ensure to clear the data for each call

--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/mapping.js
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/mapping.js
@@ -2319,6 +2319,7 @@ $(".btnDone").click(function(){
 					selected_marker.attributes.intersectionID = $("#intersection").val();
 					intersectionID = $("#intersection").val();
 					selected_marker.attributes.regionID = $("#region").val();
+					selected_marker.attributes.roadAuthorityIdType = $("#road_authority_id_type").val();
 					selected_marker.attributes.roadAuthorityId = $("#road_authority_id").val();
 					selected_marker.attributes.majorVersion = $("#major_version").val();
 					selected_marker.attributes.minorVersion = $("#minor_version").val();
@@ -2526,7 +2527,24 @@ function toggleWidthArray() {
     if (isNegative.value){
         alert("Width deltas sum to less than zero on lane " + lanes.features[isNegative.lane].attributes.laneNumber + " at node " + isNegative.node + "!");
     }
+}
 
+function onRegionIdChangeCallback(regionId){
+    if(!isNaN(regionId) && parseFloat(regionId)===0){
+        $("#road_authority_id").attr('data-parsley-required', true);
+        $("#road_authority_id_type").attr('data-parsley-required', true);
+    }else{
+        $("#road_authority_id").attr('data-parsley-required', false);
+        $("#road_authority_id_type").attr('data-parsley-required', false);
+    }
+}
+
+function onRoadAuthorityIdTypeChangeCallback(roadAuthorityIdType){
+	if(roadAuthorityIdType!==""){
+		$("#road_authority_id").attr('data-parsley-required', true);
+	}else{
+		$("#road_authority_id").attr('data-parsley-required', false);
+	}
 }
 
 function isOdd(num) { return (num % 2) == 1;}

--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/mapping.js
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/mapping.js
@@ -453,6 +453,9 @@ async function init() {
 		        	$(".verified_long").hide();
 		        	$(".intersection").hide();
 					$(".region").hide();
+					show_rga_fields(hide=true);
+					$('.road_authority_id').hide();
+					$('.road_authority_id_type').hide();
 		        	$(".elev").hide();
 		        	$(".verified_elev").hide();
 		        	$(".lane_width").hide();
@@ -563,6 +566,7 @@ async function init() {
                 $(".intersection_name").hide();
                 show_rga_fields(hide=true);
 				$('.road_authority_id').hide();
+				$('.road_authority_id_type').hide();
                 $(".approach_name").hide();
                 $(".shared_with").hide();
                 $(".btnClone").hide();
@@ -1357,6 +1361,9 @@ function placeComputedLane(newDotFeature) {
 			$(".approach_type").hide();
 			$(".intersection").hide();
 			$(".region").hide();
+			show_rga_fields(hide=true);
+			$('.road_authority_id').hide();
+			$('.road_authority_id_type').hide();
 			$(".revision").hide();
 			$('.phases').hide();
 			$(".master_lane_width").hide();
@@ -1745,6 +1752,7 @@ function referencePointWindow(feature){
     //Show additional RGA related fields
     show_rga_fields(hide=false);
 	$('.road_authority_id').show();
+	$('.road_authority_id_type').show();
     
     $(".master_lane_width").show();
     $(".intersection_name").show();
@@ -1774,6 +1782,7 @@ function referencePointWindow(feature){
         
         show_rga_fields(hide=true);
 		$('.road_authority_id').hide();
+		$('.road_authority_id_type').hide();
 	}
         
         if(feature.attributes.marker.name == "Reference Point Marker"){    
@@ -1833,6 +1842,12 @@ function referencePointWindow(feature){
         $("#road_authority_id").val("");
     } else {
         $("#road_authority_id").val(selected_marker.attributes.roadAuthorityId);
+    }
+
+	if (! selected_marker.attributes.roadAuthorityIdType){
+        $("#road_authority_id_type").val("");
+    } else {
+        $("#road_authority_id_type").val(selected_marker.attributes.roadAuthorityIdType);
     }
     
     if (! selected_marker.attributes.mappedGeometryId){


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Update the UI so that users can see the full/relative RAID in the Reference Point Configuration pop up.
Implement this as a mandatory field if RRID is 0 on the UI side but still be able to provide RAID if region id is not 0 too. 
Show a RAID type as a dropdown.
Once RAID type is picked, then show Full RAID/Relative RAID based on selected type as a textbox (OID). 
Add switch.css file that is missed from this pull request: https://github.com/usdot-fhwa-stol/connectedvcs-tools/pull/27
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->
https://usdot-carma.atlassian.net/browse/MAP-123
## Motivation and Context
MAP tool update
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
