### PR TITLE
	modified:   Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM gradle:7.4.2-jdk8 AS gradle-build
+FROM gradle:7.4.2-jdk11 AS gradle-build
 ARG TOKEN
 RUN git clone https://$TOKEN@github.com/usdot-fhwa-stol/CARMASensitive.git 
 RUN ls -la && pwd
-FROM maven:3.8.5-jdk-8-slim AS mvn-build
+FROM maven:3.8.5-jdk-11-slim AS mvn-build
 ADD . /root
 
 # Run the Maven build
@@ -20,7 +20,7 @@ RUN cd /root/fedgov-cv-TIMcreator-webapp \
     && mvn install -DskipTests
 RUN jar cvf /root/root.war -C /root/root .
 
-FROM jetty:9.4.46-jre8-slim
+FROM jetty:9.4.46-jre11-slim
 # Install the generated WAR files
 COPY --from=mvn-build /root/fedgov-cv-ISDcreator-webapp/target/isd.war /var/lib/jetty/webapps 
 COPY --from=mvn-build /root/fedgov-cv-TIMcreator-webapp/target/tim.war /var/lib/jetty/webapps
@@ -43,5 +43,5 @@ RUN cd /var/lib/jetty \
 RUN java -jar $JETTY_HOME/start.jar --create-files
 
 RUN java -jar $JETTY_HOME/start.jar --add-to-start=https
-COPY --from=gradle-build /home/gradle/CARMASensitive/maptool/keystore* /var/lib/jetty/etc
+COPY --from=gradle-build /home/gradle/CARMASensitive/maptool/keystore* /var/lib/jetty/etc/
 COPY --from=gradle-build /home/gradle/CARMASensitive/maptool/ssl.ini /var/lib/jetty/start.d/


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Updated Dockerfile to use JDK-11 instead of JDK-8.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

Allows for new SSL certs to be used by final image. Previous JDK version could not use the keystore. 

## How Has This Been Tested?
Build image and briefly tested functionality.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
