### PR TITLE
Updated regex to fit OID requirements

### DIFF
--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/index.html
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/index.html
@@ -429,7 +429,8 @@
 							</div>
 							<div class="row road_authority_id">
 								<div class="col-sm-4"><label for="road_authority_id">Road Authority ID:</label></div>
-								<div class="col-sm-7"><input class="form-control" id="road_authority_id" placeholder="xx.xx.xx"></div>
+								<div class="col-sm-7"><input class="form-control" id="road_authority_id" placeholder="xx.xx.xx" data-parsley-required="true" data-parsley-pattern='^(([01]\.(0|[1-9]|[1-2][0-9]|3[0-9]))|(2\.[0-9]+))(\.[0-9]+)*$' data-parsley-pattern-message="RAID must be integers separated by a period. The first integer should be either 0, 1, or 2.
+									 If the first integer is either 0 or 1, the second integer cannot exceed 40"></div>
 								<div class="col-sm-1"><i class="fa fa-question-circle" aria-hidden="true" tag="road_authority_id"></i></div>
 							</div>
 							<div class="row mapped_geometry_id extra_rga_field">

--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/index.html
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/index.html
@@ -429,8 +429,7 @@
 							</div>
 							<div class="row road_authority_id">
 								<div class="col-sm-4"><label for="road_authority_id">Road Authority ID:</label></div>
-								<div class="col-sm-7"><input class="form-control" id="road_authority_id" placeholder="xx.xx.xx" data-parsley-required="true" data-parsley-pattern='^(([01]\.(0|[1-9]|[1-2][0-9]|3[0-9]))|(2\.[0-9]+))(\.[0-9]+)*$' data-parsley-pattern-message="RAID must be integers separated by a period. The first integer should be either 0, 1, or 2.
-									 If the first integer is either 0 or 1, the second integer cannot exceed 40"></div>
+								<div class="col-sm-7"><input class="form-control" id="road_authority_id" placeholder="xx.xx.xx" data-parsley-required="true" data-parsley-pattern='([0-9]+(\.[0-9]+)+)' data-parsley-pattern-message="RAID must be integers separated by a period. The first integer should be either 0, 1, or 2."></div>
 								<div class="col-sm-1"><i class="fa fa-question-circle" aria-hidden="true" tag="road_authority_id"></i></div>
 							</div>
 							<div class="row mapped_geometry_id extra_rga_field">

--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/mapping.js
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/mapping.js
@@ -2543,8 +2543,8 @@ function onRoadAuthorityIdTypeChangeCallback(roadAuthorityIdType){
 	if(roadAuthorityIdType!==""){
 		$("#road_authority_id").attr('data-parsley-required', true);
 		if (roadAuthorityIdType === "full") {
-            roadAuthorityIdInput.attr("data-parsley-pattern", "([0-2](\.[0-9]+)+)");
-            roadAuthorityIdInput.attr("data-parsley-pattern-message", "For Full RAID, the first integer must be 0-2, with at least one period-separated integer.");
+            roadAuthorityIdInput.attr("data-parsley-pattern", "^(([01]\.(0|[1-9]|[1-2][0-9]|3[0-9]))|(2\.[0-9]+))(\.[0-9]+)*$");
+            roadAuthorityIdInput.attr("data-parsley-pattern-message", "For Full RAID, the first integer must be 0-2, with at least one period-separated integer. If the first integer is either 0 or 1, the second integer cannot exceed 40.");
         } else if (roadAuthorityIdType === "relative") {
             roadAuthorityIdInput.attr("data-parsley-pattern", "([0-9]+(\.[0-9]+)+)");
             roadAuthorityIdInput.attr("data-parsley-pattern-message", "For Relative RAID, enter at least two integers separated by a period.");

--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/mapping.js
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/mapping.js
@@ -2544,7 +2544,7 @@ function onRoadAuthorityIdTypeChangeCallback(roadAuthorityIdType){
 		$("#road_authority_id").attr('data-parsley-required', true);
 		if (roadAuthorityIdType === "full") {
             roadAuthorityIdInput.attr("data-parsley-pattern", "^(([01]\.(0|[1-9]|[1-2][0-9]|3[0-9]))|(2\.[0-9]+))(\.[0-9]+)*$");
-            roadAuthorityIdInput.attr("data-parsley-pattern-message", "For Full RAID, the first integer must be 0-2, with at least one period-separated integer. If the first integer is either 0 or 1, the second integer cannot exceed 40.");
+            roadAuthorityIdInput.attr("data-parsley-pattern-message", "For Full RAID, the first integer must be 0-2, with at least one period-separated integer. If the first integer is either 0 or 1, the second integer cannot be greater than 39.");
         } else if (roadAuthorityIdType === "relative") {
             roadAuthorityIdInput.attr("data-parsley-pattern", "([0-9]+(\.[0-9]+)+)");
             roadAuthorityIdInput.attr("data-parsley-pattern-message", "For Relative RAID, enter at least two integers separated by a period.");


### PR DESCRIPTION
# PR Details
## Description

Needed to update the regex controlling the Road Authority ID to ensure that the first number is either a 0 1 or 2, and if it's 0 or 1, then the second number needs to be less than 40.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[MAP-220](https://usdot-carma.atlassian.net/browse/MAP-220)

## Motivation and Context

Updated to meet requirements of OID

## How Has This Been Tested?

Updated the index.html file that contains the regex, built and tested the field with the different conditions to ensure that the behavior is as expected

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[MAP-220]: https://usdot-carma.atlassian.net/browse/MAP-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ