### PR TITLE
MAP 291 - Fix CI/CD pipeline errors

### DIFF
--- a/fedgov-cv-message-builder/pom.xml
+++ b/fedgov-cv-message-builder/pom.xml
@@ -152,10 +152,11 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
 				<configuration>
-					<!-- Increase JVM memory -->
-					<argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
-					<!-- Optionally enable debugging for tests -->
-					<debugForkedProcess>true</debugForkedProcess>
+					<argLine>-Xmx1024m</argLine>
+					<parallel>classes</parallel>
+					<threadCount>4</threadCount>
+					<reuseForks>true</reuseForks>
+					<debugForkedProcess>false</debugForkedProcess>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/fedgov-cv-message-builder/pom.xml
+++ b/fedgov-cv-message-builder/pom.xml
@@ -147,6 +147,17 @@
 					<target>${java.version}</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+				<configuration>
+					<!-- Increase JVM memory -->
+					<argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+					<!-- Optionally enable debugging for tests -->
+					<debugForkedProcess>true</debugForkedProcess>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/fedgov-cv-message-builder/pom.xml
+++ b/fedgov-cv-message-builder/pom.xml
@@ -150,7 +150,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0-M5</version>
 				<configuration>
 					<argLine>-Xmx1024m</argLine>
 					<parallel>classes</parallel>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
In this PR, worked on fixing CI/CD pipeline by
- Upgrading the maven-surefire-plugin to 3.0.0-M5 from 2.12.4
- Disabling debugging on libasn1c.so file

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
MAP-291
<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
