### PR TITLE
added scrollbars to connection, approach, and speed limit config panels

### DIFF
--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/css/verticalscroll.css
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/css/verticalscroll.css
@@ -1,0 +1,48 @@
+.panel,
+.panel-body,
+.tab-content,
+.tab-pane {
+    overflow: visible !important;
+    max-height: none !important;
+}
+#speedForm {
+    max-height: 525px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    border: 1px solid #ddd;
+    padding: 10px; 
+}
+#tab_intersects {
+    max-height: 500px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    display: block;
+}
+table#tab_approaches {
+  display: block;
+  max-height: 425px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+#speedForm::-webkit-scrollbar,
+#tab_intersects::-webkit-scrollbar,
+#tab_approaches::-webkit-scrollbar {
+    width: 8px;
+}
+#speedForm::-webkit-scrollbar-track,
+#tab_intersects::-webkit-scrollbar-track,
+#tab_approaches::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 4px;
+}
+#speedForm::-webkit-scrollbar-thumb,
+#tab_intersects::-webkit-scrollbar-thumb,
+#tab_approaches::-webkit-scrollbar-thumb {
+    background: #ccc;
+    border-radius: 4px;
+}
+#speedForm::-webkit-scrollbar-thumb:hover,
+#tab_intersects::-webkit-scrollbar-thumb:hover,
+#tab_approaches::-webkit-scrollbar-thumb:hover {
+    background: #aaa;
+}

--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/index.html
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/index.html
@@ -34,6 +34,7 @@
 	<link href="external/bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css" rel="stylesheet">
 	<link rel="stylesheet" href="external/ol_v10.4.0/ol.css">
 	<link rel="stylesheet" href="external/ol-layerswitcher.css">
+	<link rel="stylesheet" href="css/verticalscroll.css">
 
 </head>
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Added vertical scrollbars to connection, approach, and speed limit configuration panels.
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
MAP-335
<!-- e.g. CAR-123 -->

## Motivation and Context
In the Lane, Approach, and Reference Point configuration panels, the UI often extends beyond the screen when adding multiple rows of connections, approaches, or speed limits. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local Docker Deployment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
