### PR TITLE
added vcsWkid

### DIFF
--- a/fedgov-cv-map-services-proxy/src/main/java/gov/usdot/cv/esrimap/models/EsriSpatialReference.java
+++ b/fedgov-cv-map-services-proxy/src/main/java/gov/usdot/cv/esrimap/models/EsriSpatialReference.java
@@ -15,12 +15,17 @@
  */
 package gov.usdot.cv.esrimap.models;
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EsriSpatialReference {
     @JsonProperty("wkid")
     @JsonAlias("wkid")
     private double wkid;
+
+    @JsonProperty("vcsWkid")
+    @JsonAlias("vcsWkid")
     private double vcsWkid;
 
     public EsriSpatialReference() {}

--- a/fedgov-cv-map-services-proxy/src/main/java/gov/usdot/cv/esrimap/models/EsriSpatialReference.java
+++ b/fedgov-cv-map-services-proxy/src/main/java/gov/usdot/cv/esrimap/models/EsriSpatialReference.java
@@ -21,25 +21,35 @@ public class EsriSpatialReference {
     @JsonProperty("wkid")
     @JsonAlias("wkid")
     private double wkid;
+    private double vcsWkid;
 
     public EsriSpatialReference() {}
 
-    public EsriSpatialReference(double wkid) {
+    public EsriSpatialReference(double wkid, double vcsWkid) {
         this.wkid = wkid;
+        this.vcsWkid = vcsWkid;
     }
 
     public double getWkid() {
         return this.wkid;
+
+    }public double getVcsWkid() {
+        return this.vcsWkid;
     }
 
     public void setWkid(double wkid) {
         this.wkid = wkid;
     }
 
+    public void setVcsWkid(double vcsWkid) {
+        this.vcsWkid= vcsWkid;
+    }
+
     @Override
     public String toString() {
         return "{" +
             " wkid='" + getWkid() + "'" +
+            " wkid='" + getVcsWkid() + "'" +
             "}";
     }
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Added vcsWkid to the EsriSpatialReference file.
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
MAP-348
<!-- e.g. CAR-123 -->

## Motivation and Context
Esri Elevation API logic returned -9999 when placing Reference Point Marker, Verified Point Marker, or new lanes. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local Docker Deployment Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] have added tests to cover my changes.
- [x] All new and existing tests passed.
