### PR TITLE
fixed right u-turn to be draggable

### DIFF
--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/map.js
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/map.js
@@ -824,15 +824,21 @@ function initSideBar() {
     if (rgaEnabled) {
         // Enable Right U-Turn image
         rightUTurnImg.addClass('drag-lane-img')  // Add the droppable class back
+          .addClass('ui-draggable')
+          .addClass('ui-draggable-handle')
             .removeClass('disabled-lane-img') // Add a class to indicate it's disabled
                     .css({
                         'opacity': '1',
                         'filter': 'none',
                         'pointer-events': 'auto'
                     });
+        
+                    makeImgsDraggable()
     } else {
         // Disable Right U-Turn image
         rightUTurnImg.removeClass('drag-lane-img')
+        .removeClass('ui-draggable')
+        .removeClass('ui-draggable-handle')
         .addClass('disabled-lane-img') // Add a class to indicate it's disabled
                     .css({
                         'opacity': '0.5',
@@ -842,6 +848,11 @@ function initSideBar() {
     }
 });
 
+makeImgsDraggable()
+  
+}
+
+function makeImgsDraggable() {
   $imgs = intersectionSidebar.find(".drag-intersection-img,.drag-lane-img");
   $imgs.draggable({
     appendTo: "body",
@@ -885,7 +896,6 @@ function initSideBar() {
       }
     },
   }); 
-  
 }
  /**
    * Purpose: clone marker image onto layer


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fixed a bug where the Right U Turn maneuver was not made draggable into the connections box when RGA was enabled.
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
MAP-356
<!-- e.g. CAR-123 -->

## Motivation and Context
Bug fix for RGA maneuver.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local Docker Deployment Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
