### PR TITLE
Decoder JNI Wrapper Updated to Include SDSM Messages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,17 +18,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$BASE_DIR"
+
 if [[ "$SKIP_TESTS" = "true" ]]; then
     MVN_ARGS="-DskipTests=true"
     echo "Building without tests..."
 else
     MVN_ARGS=""
-    export LD_LIBRARY_PATH="./fedgov-cv-lib-asn1c/lib"
+    export LD_LIBRARY_PATH="${BASE_DIR}/fedgov-cv-lib-asn1c/lib"
     echo "Building with tests..."
 fi
-
-BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$BASE_DIR"
 
 cd fedgov-cv-parent
 mvn clean install $MVN_ARGS

--- a/fedgov-cv-asn1decoder/src/test/java/gov/usdot/cv/asn1decoder/ASN1DecoderTest.java
+++ b/fedgov-cv-asn1decoder/src/test/java/gov/usdot/cv/asn1decoder/ASN1DecoderTest.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Logger;
 public class ASN1DecoderTest {
 
     private static final Logger logger = LogManager.getLogger(ASN1DecoderTest.class);
+    private static final String SDSM = "SensorDataSharingMessage";
 
     private Decoder decoder;
 
@@ -50,6 +51,7 @@ public class ASN1DecoderTest {
     private ByteArrayObject onlyspatMsg;
     private ByteArrayObject onlySDSMMsgFrame;
     private ByteArrayObject onlySDSMMsg;
+
 
 
     
@@ -183,7 +185,7 @@ public class ASN1DecoderTest {
         );
 
         onlySDSMMsgFrame = mock(ByteArrayObject.class);
-        when(onlySDSMMsgFrame.getType()).thenReturn("SensorDataSharingMessage");
+        when(onlySDSMMsgFrame.getType()).thenReturn(SDSM);
         when(onlySDSMMsgFrame.getMessage()).thenReturn(
                 DatatypeConverter.parseHexBinary(
                         "002980840a303030303fdfa7234b5b9eda409510574470ea4793fffffffe09003942d39900940543f2b807ffc2aec0012324748020072c98ab20127f4681b700fff8b60000246f10d00400e58ce4640250240fac001fff09c4c0048fe28100801cac4fec804a0309f86403ffe0000000918a38a010059428519009404d4000007ffc43bf0f9230155001900002765c639eda0814e2a5b8cd2cf514070381010100030180c620fb90caad3b9c508208c6aa68e0f00ede4b396921000329467f5a8400a98301018003480108800182800500800130408001838005008001f04000018780032040958005000001e040800320409780050080012040000320409900012700019081825c9223e759fe71a740c6819635fa595611888b45e760f51c5cc469b39b428f3f808240b97a393a333e06c5353fb6ade829870c35ce858af665778375136547ac932871da55b7823b45ddb589edbb24940be13918de8a9c90d04464be7df5cf0a4362"
@@ -191,7 +193,7 @@ public class ASN1DecoderTest {
         );
 
         onlySDSMMsg = mock(ByteArrayObject.class);
-        when(onlySDSMMsg.getType()).thenReturn("SensorDataSharingMessage");
+        when(onlySDSMMsg.getType()).thenReturn(SDSM);
         when(onlySDSMMsg.getMessage()).thenReturn(
                 DatatypeConverter.parseHexBinary(
                         "0a303030303fdfa7234b5b9eda409510574470ea4793fffffffe09003942d39900940543f2b807ffc2aec0012324748020072c98ab20127f4681b700fff8b60000246f10d00400e58ce4640250240fac001fff09c4c0048fe28100801cac4fec804a0309f86403ffe0000000918a38a010059428519009404d4000007ffc43bf0f9230155001900002765c639eda0814e2a5b8cd2cf514070381010100030180c620fb90caad3b9c508208c6aa68e0f00ede4b396921000329467f5a8400a98301018003480108800182800500800130408001838005008001f04000018780032040958005000001e040800320409780050080012040000320409900012700019081825c9223e759fe71a740c6819635fa595611888b45e760f51c5cc469b39b428f3f808240b97a393a333e06c5353fb6ade829870c35ce858af665778375136547ac932871da55b7823b45ddb589edbb24940be13918de8a9c90d04464be7df5cf0a4362"
@@ -315,7 +317,7 @@ public class ASN1DecoderTest {
         Assert.assertFalse(r.decodedMessage.isEmpty());
         Assert.assertEquals(
             "Expected decoded message type to be 'SensorDataSharingMessage'",
-            "SensorDataSharingMessage",
+            SDSM,
             r.messageType
         );
     }
@@ -395,7 +397,7 @@ public class ASN1DecoderTest {
                Assert.assertFalse(r.decodedMessage.isEmpty());
                  Assert.assertEquals(
                         "Expected decoded message type to be 'SensorDataSharingMessage'",
-                        "SensorDataSharingMessage",
+                        SDSM,
                         r.messageType
                 );    
         }

--- a/fedgov-cv-asn1decoder/src/test/java/gov/usdot/cv/asn1decoder/ASN1DecoderTest.java
+++ b/fedgov-cv-asn1decoder/src/test/java/gov/usdot/cv/asn1decoder/ASN1DecoderTest.java
@@ -48,6 +48,9 @@ public class ASN1DecoderTest {
     private ByteArrayObject onlypsmMsg;
     private ByteArrayObject onlymapMsg;
     private ByteArrayObject onlyspatMsg;
+    private ByteArrayObject onlySDSMMsgFrame;
+    private ByteArrayObject onlySDSMMsg;
+
 
     
 
@@ -179,6 +182,22 @@ public class ASN1DecoderTest {
                 )
         );
 
+        onlySDSMMsgFrame = mock(ByteArrayObject.class);
+        when(onlySDSMMsgFrame.getType()).thenReturn("SensorDataSharingMessage");
+        when(onlySDSMMsgFrame.getMessage()).thenReturn(
+                DatatypeConverter.parseHexBinary(
+                        "002980840a303030303fdfa7234b5b9eda409510574470ea4793fffffffe09003942d39900940543f2b807ffc2aec0012324748020072c98ab20127f4681b700fff8b60000246f10d00400e58ce4640250240fac001fff09c4c0048fe28100801cac4fec804a0309f86403ffe0000000918a38a010059428519009404d4000007ffc43bf0f9230155001900002765c639eda0814e2a5b8cd2cf514070381010100030180c620fb90caad3b9c508208c6aa68e0f00ede4b396921000329467f5a8400a98301018003480108800182800500800130408001838005008001f04000018780032040958005000001e040800320409780050080012040000320409900012700019081825c9223e759fe71a740c6819635fa595611888b45e760f51c5cc469b39b428f3f808240b97a393a333e06c5353fb6ade829870c35ce858af665778375136547ac932871da55b7823b45ddb589edbb24940be13918de8a9c90d04464be7df5cf0a4362"
+                )
+        );
+
+        onlySDSMMsg = mock(ByteArrayObject.class);
+        when(onlySDSMMsg.getType()).thenReturn("SensorDataSharingMessage");
+        when(onlySDSMMsg.getMessage()).thenReturn(
+                DatatypeConverter.parseHexBinary(
+                        "0a303030303fdfa7234b5b9eda409510574470ea4793fffffffe09003942d39900940543f2b807ffc2aec0012324748020072c98ab20127f4681b700fff8b60000246f10d00400e58ce4640250240fac001fff09c4c0048fe28100801cac4fec804a0309f86403ffe0000000918a38a010059428519009404d4000007ffc43bf0f9230155001900002765c639eda0814e2a5b8cd2cf514070381010100030180c620fb90caad3b9c508208c6aa68e0f00ede4b396921000329467f5a8400a98301018003480108800182800500800130408001838005008001f04000018780032040958005000001e040800320409780050080012040000320409900012700019081825c9223e759fe71a740c6819635fa595611888b45e760f51c5cc469b39b428f3f808240b97a393a333e06c5353fb6ade829870c35ce858af665778375136547ac932871da55b7823b45ddb589edbb24940be13918de8a9c90d04464be7df5cf0a4362"
+                )
+        );
+
         // Empty Message
         emptyMsg = mock(ByteArrayObject.class);
         when(emptyMsg.getMessage()).thenReturn(new byte[]{}); 
@@ -288,6 +307,19 @@ public class ASN1DecoderTest {
             r2.messageType
         );
     }
+
+    @Test
+    public void testDecodeSDSMFrame() {
+        DecodedResult r = decoder.decode(onlySDSMMsgFrame, "MessageFrame");
+        Assert.assertTrue(r.success);
+        Assert.assertFalse(r.decodedMessage.isEmpty());
+        Assert.assertEquals(
+            "Expected decoded message type to be 'SensorDataSharingMessage'",
+            "SensorDataSharingMessage",
+            r.messageType
+        );
+    }
+    
     @Test
     public void ASN1DecoderTestEmpty() {
         DecodedResult decodedMessage = decoder.decode(emptyMsg,"empty");
@@ -355,5 +387,17 @@ public class ASN1DecoderTest {
                         r.messageType
                 );    
         }  
+        @Test
+        public void testDecodeOnlySDSM() {    
+        
+                DecodedResult r = decoder.decode( onlySDSMMsg, "SDSM");
+                Assert.assertTrue(r.success);
+               Assert.assertFalse(r.decodedMessage.isEmpty());
+                 Assert.assertEquals(
+                        "Expected decoded message type to be 'SensorDataSharingMessage'",
+                        "SensorDataSharingMessage",
+                        r.messageType
+                );    
+        }
 
 }

--- a/fedgov-cv-lib-asn1c/src/main/java/decoder_wrapper.c
+++ b/fedgov-cv-lib-asn1c/src/main/java/decoder_wrapper.c
@@ -198,6 +198,11 @@ JNIEXPORT jobject JNICALL Java_gov_usdot_cv_asn1decoder_Decoder_decodeMsg(JNIEnv
             asn_def = &asn_DEF_MapData;
             messageType = "MapData";
         }
+        else if (type && strcmp(type, "SDSM") == 0)
+        {
+            asn_def = &asn_DEF_SensorDataSharingMessage;
+            messageType = "SensorDataSharingMessage";
+        }
         else
         {
             

--- a/fedgov-cv-lib-asn1c/src/main/java/decoder_wrapper.c
+++ b/fedgov-cv-lib-asn1c/src/main/java/decoder_wrapper.c
@@ -150,6 +150,9 @@ JNIEXPORT jobject JNICALL Java_gov_usdot_cv_asn1decoder_Decoder_decodeMsg(JNIEnv
             case 32:
                 msgTypeStr = "PersonalSafetyMessage";
                 break;
+            case 41:
+                msgTypeStr = "SensorDataSharingMessage";
+                break;
             default:
                 msgTypeStr = "UnknownMessageType";
                 break;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

JNI Wrapper for the decoder was updated to include SDSM/SDSM+MessageFrame messages

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[CVCS-158](https://usdot-carma.atlassian.net/browse/CVCS-158?atlOrigin=eyJpIjoiOWJmYWUzNGJiOGEyNDNjNWE5NTVjZjI3N2Y1ZjMzYzQiLCJwIjoiaiJ9)

## Motivation and Context

Updated to include SDSM messages as part of the Message Validator 

## How Has This Been Tested?

Local unit testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CVCS-158]: https://usdot-carma.atlassian.net/browse/CVCS-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ