### PR TITLE
CVCS-169 BSM Bitstring Decoding

### DIFF
--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/depositor-latest.js
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/depositor-latest.js
@@ -722,7 +722,7 @@ function createMessageJSON()
         $('#alert_placeholder').append(
             '<div class="alert alert-danger alert-dismissable">' +
             '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>' +
-            '<span> There exists ' + inBoxErrorCounter + ' lane(s) outside of an approach. Check error markers.</span></div>'
+            '<span> ' + inBoxErrorCounter + ' lane(s) exist outside of an approach. Check error markers.</span></div>'
         );
         $('#message_alert').removeClass('alert-section-hidden');
     }
@@ -731,7 +731,7 @@ function createMessageJSON()
         $('#alert_placeholder').append(
             '<div class="alert alert-danger alert-dismissable">' +
             '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>' +
-            '<span> There exists ' + laneNumberErrorCounter + ' lane(s) without a assigned lane number. Check overlapping points.</span></div>'
+            '<span> ' + laneNumberErrorCounter + ' lane(s) exist without a assigned lane number. Check overlapping points.</span></div>'
         );
         $('#message_alert').removeClass('alert-section-hidden');
     }

--- a/fedgov-cv-asn1decoder/src/main/java/gov/usdot/cv/asn1decoder/util/BSMBitStringProcessor.java
+++ b/fedgov-cv-asn1decoder/src/main/java/gov/usdot/cv/asn1decoder/util/BSMBitStringProcessor.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package gov.usdot.cv.asn1decoder.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BSMBitStringProcessor {
+
+    /**
+     * ExteriorLights bit names 
+     */
+    private static final String[] EXTERIOR_LIGHTS = {
+        "lowBeamHeadlightsOn",          // 0
+        "highBeamHeadlightsOn",                         // 1
+        "leftTurnSignalOn",              // 2
+        "rightTurnSignalOn",                 // 3
+        "hazardSignalOn",             // 4
+        "automaticLightControlOn",                 // 5
+        "daytimeRunningLightsOn",          // 6
+        "fogLightsOn",             // 7
+        "parkingLightsOn"                     // 8
+    };
+
+    /**
+     * HeadingSlice bit names
+     */
+    private static final String[] HEADING_SLICE = {
+        "from000-0to022-5degrees",                      // 0
+        "from022-5to045-0degrees",                      // 1
+        "from045-0to067-5degrees",                    // 2
+        "from067-5to090-0degrees",                      // 3
+        "from090-0to112-5degrees",                      // 4
+        "from112-5to135-0degrees",                     // 5
+        "from135-0to157-5degrees",                         // 6
+        "from157-5to180-0degrees",                      // 7
+        "from180-0to202-5degrees",                      // 8
+        "from202-5to225-0degrees",                      // 9
+        "from225-0to247-5degrees",                      // 10
+        "from247-5to270-0degrees",                      // 11
+        "from270-0to292-5degrees",                      // 12
+        "from292-5to315-0degrees",                      // 13
+        "from315-0to337-5degrees",                      // 14
+        "from337-5to360-0degrees"                       // 15
+    };
+
+    private static final String[] VEHICLE_EVENT_FLAGS = {
+        "eventHazardLights",                      // 0
+        "eventStopLineViolation",                      // 1
+        "eventABSactivated",                    // 2
+        "eventTractionControlLoss",                      // 3
+        "eventStabilityControlactivated",                      // 4
+        "eventHazardousMaterials",                     // 5
+        "eventReserved1",                         // 6
+        "eventHardBraking",                         // 7
+        "eventLightsChanged",                         // 8
+        "eventWipersChanged",                         // 9
+        "eventFlatTire",                         // 10
+        "eventDisabledVehicle",                         // 11
+        "eventAirBagDeployment",                         // 12
+        "eventJackKnife"
+    };
+
+    private static final String[] BRAKE_APPLIED_STATUS = {
+        "unavailable",
+        "leftFront",
+        "leftRear",
+        "rightFront",
+        "rightRear"
+    };
+
+    
+
+    private static final Map<String, String[]> FIELD_TO_NAMES = new HashMap<>();
+    static {
+        FIELD_TO_NAMES.put("lights",      EXTERIOR_LIGHTS);
+        FIELD_TO_NAMES.put("headingSlice",       HEADING_SLICE);
+        FIELD_TO_NAMES.put("events", VEHICLE_EVENT_FLAGS);
+        FIELD_TO_NAMES.put("wheelBrakes", BRAKE_APPLIED_STATUS);
+    };
+
+    private static final Pattern BIT_STRING_PATTERN = Pattern.compile(
+        "\\b(lights|headingSlice|events|wheelBrakes)" +
+        ":\\s*([0-9A-Fa-f]{1,2}(?:\\s++[0-9A-Fa-f]{1,2})*+)\\s*" +
+        "\\((\\d+)\\s*bits?\\s*unused\\)"
+    );
+
+    public static String processBSMBitStrings(String decoded) {
+        if (decoded == null) return null;
+ 
+        Matcher m = BIT_STRING_PATTERN.matcher(decoded);
+        StringBuffer out = new StringBuffer();
+        while (m.find()) {
+            String fieldName = m.group(1);
+            String hex       = m.group(2).trim();
+            int unusedBits   = Integer.parseInt(m.group(3));
+            String[] names   = FIELD_TO_NAMES.get(fieldName);
+ 
+            if (names == null) {
+                // Regex said yes but dispatch table says no — leave unchanged.
+                m.appendReplacement(out, Matcher.quoteReplacement(m.group(0)));
+                continue;
+            }
+ 
+            String readable = BitStringUtil.decodeBitString(hex, unusedBits, names);
+            m.appendReplacement(out, Matcher.quoteReplacement(fieldName + ": " + readable));
+        }
+        m.appendTail(out);
+        return out.toString();
+    }
+ 
+ 
+    private BSMBitStringProcessor() { /* utility class */ }
+}   

--- a/fedgov-cv-asn1decoder/src/test/java/gov/usdot/cv/asn1decoder/BitStringProcessorTest.java
+++ b/fedgov-cv-asn1decoder/src/test/java/gov/usdot/cv/asn1decoder/BitStringProcessorTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package gov.usdot.cv.asn1decoder.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the BIT STRING post-processors
+ * ({@link MAPBitStringProcessor} and {@link BSMBitStringProcessor}).
+ *
+ * Both processors are pure Java (regex + dispatch table + {@link BitStringUtil}),
+ * so these tests run without the native asn1c library. Expected values are
+ * hand-derived from the MSB-first decoding in {@code BitStringUtil}: bit i
+ * (0-based, MSB-first) maps to the i-th name in the field's array, only set bits
+ * are emitted inside {@code "{ ... }"}, and the scan is bounded by both the live
+ * bit count (bytes*8 - unusedBits) and the array length.
+ */
+public class BitStringProcessorTest {
+
+    // MAPBitStringProcessor
+
+    @Test
+    public void mapNullInputReturnsNull() {
+        Assert.assertNull(MAPBitStringProcessor.processMapBitStrings(null));
+    }
+
+    @Test
+    public void mapEmptyStringReturnsEmptyString() {
+        Assert.assertEquals("", MAPBitStringProcessor.processMapBitStrings(""));
+    }
+
+    @Test
+    public void mapTextWithoutBitStringIsUnchanged() {
+        String input = "MapData ::= { intersections : ... } no bit strings here";
+        Assert.assertEquals(input, MAPBitStringProcessor.processMapBitStrings(input));
+    }
+
+    @Test
+    public void mapUnrecognizedFieldNameIsLeftUnchanged() {
+        String input = "speed: 80 (4 bits unused)";
+        Assert.assertEquals(input, MAPBitStringProcessor.processMapBitStrings(input));
+    }
+
+    @Test
+    public void mapManeuversSingleBit() {
+        // 0x80 = 1000 0000 -> bit 0 set; 4 unused bits -> only first 4 bits considered.
+        Assert.assertEquals(
+            "maneuvers: { maneuverStraightAllowed }",
+            MAPBitStringProcessor.processMapBitStrings("maneuvers: 80 (4 bits unused)"));
+    }
+
+    @Test
+    public void mapManeuversMultipleBits() {
+        // 0xC0 = 1100 0000 -> bits 0 and 1 set.
+        Assert.assertEquals(
+            "maneuvers: { maneuverStraightAllowed maneuverLeftAllowed }",
+            MAPBitStringProcessor.processMapBitStrings("maneuvers: C0 (4 bits unused)"));
+    }
+
+    @Test
+    public void mapManeuversAllEightBitsSet() {
+        // 0xFF, 0 unused -> first 8 maneuver names (array has 12 entries).
+        Assert.assertEquals(
+            "maneuvers: { maneuverStraightAllowed maneuverLeftAllowed maneuverRightAllowed "
+                + "maneuverUTurnAllowed maneuverLeftTurnOnRedAllowed maneuverRightTurnOnRedAllowed "
+                + "maneuverLaneChangeAllowed maneuverNoStoppingAllowed }",
+            MAPBitStringProcessor.processMapBitStrings("maneuvers: FF (0 bits unused)"));
+    }
+
+    @Test
+    public void mapNoBitsSetProducesEmptyBraces() {
+        Assert.assertEquals(
+            "maneuvers: { }",
+            MAPBitStringProcessor.processMapBitStrings("maneuvers: 00 (0 bits unused)"));
+    }
+
+    @Test
+    public void mapManeuverSingularAliasUsesSameNames() {
+        // Dispatch table maps both "maneuvers" and "maneuver" to MANEUVER_NAMES.
+        Assert.assertEquals(
+            "maneuver: { maneuverStraightAllowed }",
+            MAPBitStringProcessor.processMapBitStrings("maneuver: 80 (4 bits unused)"));
+    }
+
+    @Test
+    public void mapDirectionalUseSingleBit() {
+        // LANE_DIRECTION_NAMES = { ingressPath, egressPath }; loop capped at names.length.
+        Assert.assertEquals(
+            "directionalUse: { ingressPath }",
+            MAPBitStringProcessor.processMapBitStrings("directionalUse: 80 (6 bits unused)"));
+    }
+
+    @Test
+    public void mapDirectionalUseBothBits() {
+        Assert.assertEquals(
+            "directionalUse: { ingressPath egressPath }",
+            MAPBitStringProcessor.processMapBitStrings("directionalUse: C0 (6 bits unused)"));
+    }
+
+    @Test
+    public void mapVehicleFieldDecodes() {
+        Assert.assertEquals(
+            "vehicle: { isVehicleRevocableLane }",
+            MAPBitStringProcessor.processMapBitStrings("vehicle: 80 (0 bits unused)"));
+    }
+
+    @Test
+    public void mapLowercaseHexIsParsed() {
+        Assert.assertEquals(
+            "vehicle: { isVehicleRevocableLane isVehicleFlyOverLane hovLaneUseOnly "
+                + "restrictedToBusUse restrictedToTaxiUse restrictedFromPublicUse "
+                + "hasIRbeaconCoverage permissionOnRequest }",
+            MAPBitStringProcessor.processMapBitStrings("vehicle: ff (0 bits unused)"));
+    }
+
+    @Test
+    public void mapSingularBitWordIsAccepted() {
+        // 0x80 on BARRIER_NAMES (median) -> first name only.
+        Assert.assertEquals(
+            "median: { median-RevocableLane }",
+            MAPBitStringProcessor.processMapBitStrings("median: 80 (1 bit unused)"));
+    }
+
+    @Test
+    public void mapMultiByteHexSpansBytes() {
+        // sharedWith -> LANE_SHARING_NAMES (9 names). "80 80" with 7 unused -> 9 live bits.
+        // bit 0 (byte0 MSB) = overlappingLaneDescriptionProvided, bit 8 (byte1 MSB) = reserved.
+        Assert.assertEquals(
+            "sharedWith: { overlappingLaneDescriptionProvided reserved }",
+            MAPBitStringProcessor.processMapBitStrings("sharedWith: 80 80 (7 bits unused)"));
+    }
+
+    @Test
+    public void mapSurroundingTextIsPreserved() {
+        Assert.assertEquals(
+            "prefix maneuvers: { maneuverStraightAllowed } suffix",
+            MAPBitStringProcessor.processMapBitStrings(
+                "prefix maneuvers: 80 (4 bits unused) suffix"));
+    }
+
+    @Test
+    public void mapMultipleFieldsInOneStringAreAllReplaced() {
+        String input = "maneuvers: 80 (4 bits unused) and directionalUse: C0 (6 bits unused)";
+        String expected =
+            "maneuvers: { maneuverStraightAllowed } and "
+                + "directionalUse: { ingressPath egressPath }";
+        Assert.assertEquals(expected, MAPBitStringProcessor.processMapBitStrings(input));
+    }
+
+    @Test
+    public void mapRecognizedAndUnrecognizedFieldsMixed() {
+        String input = "speed: 80 (4 bits unused); maneuvers: 80 (4 bits unused)";
+        String expected = "speed: 80 (4 bits unused); maneuvers: { maneuverStraightAllowed }";
+        Assert.assertEquals(expected, MAPBitStringProcessor.processMapBitStrings(input));
+    }
+
+    // BSMBitStringProcessor
+
+    @Test
+    public void bsmNullInputReturnsNull() {
+        Assert.assertNull(BSMBitStringProcessor.processBSMBitStrings(null));
+    }
+
+    @Test
+    public void bsmEmptyStringReturnsEmptyString() {
+        Assert.assertEquals("", BSMBitStringProcessor.processBSMBitStrings(""));
+    }
+
+    @Test
+    public void bsmTextWithoutBitStringIsUnchanged() {
+        String input = "BasicSafetyMessage ::= { coreData ... } nothing to decode here";
+        Assert.assertEquals(input, BSMBitStringProcessor.processBSMBitStrings(input));
+    }
+
+    @Test
+    public void bsmUnrecognizedFieldNameIsLeftUnchanged() {
+        String input = "brakes: 80 (4 bits unused)";
+        Assert.assertEquals(input, BSMBitStringProcessor.processBSMBitStrings(input));
+    }
+
+    @Test
+    public void bsmExteriorLightsSingleBit() {
+        // 0x80, 7 unused -> 1 live bit -> bit 0 only.
+        Assert.assertEquals(
+            "lights: { lowBeamHeadlightsOn }",
+            BSMBitStringProcessor.processBSMBitStrings("lights: 80 (7 bits unused)"));
+    }
+
+    @Test
+    public void bsmExteriorLightsMultipleBits() {
+        // 0xA0 = 1010 0000 -> bits 0 and 2.
+        Assert.assertEquals(
+            "lights: { lowBeamHeadlightsOn leftTurnSignalOn }",
+            BSMBitStringProcessor.processBSMBitStrings("lights: A0 (0 bits unused)"));
+    }
+
+    @Test
+    public void bsmExteriorLightsNinthBitSpansSecondByte() {
+        // 9 names. "80 80" with 7 unused -> 9 live bits.
+        // bit 0 (byte0 MSB) = lowBeamHeadlightsOn, bit 8 (byte1 MSB) = parkingLightsOn (index 8).
+        Assert.assertEquals(
+            "lights: { lowBeamHeadlightsOn parkingLightsOn }",
+            BSMBitStringProcessor.processBSMBitStrings("lights: 80 80 (7 bits unused)"));
+    }
+
+    @Test
+    public void bsmHeadingSliceFirstBit() {
+        Assert.assertEquals(
+            "headingSlice: { from000-0to022-5degrees }",
+            BSMBitStringProcessor.processBSMBitStrings("headingSlice: 80 00 (0 bits unused)"));
+    }
+
+    @Test
+    public void bsmHeadingSliceFirstAndLastBit() {
+        // 0x80 0x01 -> bit 0 (byte0 MSB) and bit 15 (byte1 LSB).
+        Assert.assertEquals(
+            "headingSlice: { from000-0to022-5degrees from337-5to360-0degrees }",
+            BSMBitStringProcessor.processBSMBitStrings("headingSlice: 80 01 (0 bits unused)"));
+    }
+
+    @Test
+    public void bsmVehicleEventFlagsSingleBit() {
+        Assert.assertEquals(
+            "events: { eventHazardLights }",
+            BSMBitStringProcessor.processBSMBitStrings("events: 80 (0 bits unused)"));
+    }
+
+    @Test
+    public void bsmVehicleEventFlagsAllFourteenBits() {
+        // 14 names across two bytes. "FF FC" with 2 unused -> 14 live bits, all set:
+        // byte0 = 0xFF (bits 0-7), byte1 = 0xFC = 1111 1100 (bits 8-13 set, 14-15 unused).
+        Assert.assertEquals(
+            "events: { eventHazardLights eventStopLineViolation eventABSactivated "
+                + "eventTractionControlLoss eventStabilityControlactivated eventHazardousMaterials "
+                + "eventReserved1 eventHardBraking eventLightsChanged eventWipersChanged "
+                + "eventFlatTire eventDisabledVehicle eventAirBagDeployment eventJackKnife }",
+            BSMBitStringProcessor.processBSMBitStrings("events: FF FC (2 bits unused)"));
+    }
+
+    @Test
+    public void bsmNoBitsSetProducesEmptyBraces() {
+        Assert.assertEquals(
+            "events: { }",
+            BSMBitStringProcessor.processBSMBitStrings("events: 00 00 (2 bits unused)"));
+    }
+
+    @Test
+    public void bsmLowercaseHexIsParsed() {
+        // Lowercase hex 'ff', 1 unused -> 7 live bits (indices 0-6). Field name stays mixed-case.
+        Assert.assertEquals(
+            "lights: { lowBeamHeadlightsOn highBeamHeadlightsOn leftTurnSignalOn "
+                + "rightTurnSignalOn hazardSignalOn automaticLightControlOn daytimeRunningLightsOn }",
+            BSMBitStringProcessor.processBSMBitStrings("lights: ff (1 bit unused)"));
+    }
+
+    @Test
+    public void bsmSingularBitWordIsAccepted() {
+        Assert.assertEquals(
+            "lights: { lowBeamHeadlightsOn }",
+            BSMBitStringProcessor.processBSMBitStrings("lights: 80 (1 bit unused)"));
+    }
+
+    @Test
+    public void bsmSurroundingTextIsPreserved() {
+        Assert.assertEquals(
+            "prefix lights: { lowBeamHeadlightsOn } suffix",
+            BSMBitStringProcessor.processBSMBitStrings(
+                "prefix lights: 80 (7 bits unused) suffix"));
+    }
+
+    @Test
+    public void bsmMultipleFieldsInOneStringAreAllReplaced() {
+        String input = "lights: 80 (7 bits unused), events: 80 (0 bits unused)";
+        String expected =
+            "lights: { lowBeamHeadlightsOn }, events: { eventHazardLights }";
+        Assert.assertEquals(expected, BSMBitStringProcessor.processBSMBitStrings(input));
+    }
+
+    @Test
+    public void bsmRecognizedAndUnrecognizedFieldsMixed() {
+        String input = "brakes: 80 (4 bits unused); lights: 80 (7 bits unused)";
+        String expected = "brakes: 80 (4 bits unused); lights: { lowBeamHeadlightsOn }";
+        Assert.assertEquals(expected, BSMBitStringProcessor.processBSMBitStrings(input));
+    }
+}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

The bitstrings in BSM messages can now be properly decoded to a human readable format, matching the legacy tool. Unit tests for MAP and BSM bitstring decoding was also added. Lastly, Marisa's suggestion for the wording of error messages from the bugfix for [HELPDESK-178
](https://usdot-carma.atlassian.net/browse/HELPDESK-178?atlOrigin=eyJpIjoiMWM5NDJjYmQ5NDI3NDcwMjg1OGVmZmRjNmE3NDkwMTkiLCJwIjoiaiJ9) was also added.


## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[CVCS-169](https://usdot-carma.atlassian.net/browse/CVCS-169?atlOrigin=eyJpIjoiYjBmZmE0NTQzMWE0NGIwMjg4ZDI4OWY4MDdjNThlZTAiLCJwIjoiaiJ9)

## Motivation and Context

Better decoding representation for bitstring representation in BSM messages 

## How Has This Been Tested?

Local deployment testing, unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CVCS-169]: https://usdot-carma.atlassian.net/browse/CVCS-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ