### PR TITLE
CVCS-170: Added SPAT Bitstring decoding

### DIFF
--- a/fedgov-cv-asn1decoder/src/main/java/gov/usdot/cv/asn1decoder/Decoder.java
+++ b/fedgov-cv-asn1decoder/src/main/java/gov/usdot/cv/asn1decoder/Decoder.java
@@ -19,6 +19,8 @@ package gov.usdot.cv.asn1decoder;
 import gov.usdot.cv.libasn1decoder.DecodedResult;
 import gov.usdot.cv.asn1decoder.util.MAPBitStringProcessor;
 import gov.usdot.cv.asn1decoder.util.TIMBitStringProcessor;
+import gov.usdot.cv.asn1decoder.util.SPATBitStringProcessor;
+import gov.usdot.cv.asn1decoder.util.BSMBitStringProcessor;
 
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -84,6 +86,20 @@ public class Decoder {
                 logger.info("Applying BIT STRING decoding for TIM (Java layer)");
                 result.decodedMessage =
                     TIMBitStringProcessor.processTIMBitStrings(result.decodedMessage);
+            }
+
+			if (result.decodedMessage != null
+                    && result.decodedMessage.contains("SPAT ::=")) {
+                logger.info("Applying BIT STRING decoding for SPAT (Java layer)");
+                result.decodedMessage =
+                    SPATBitStringProcessor.processSPATBitStrings(result.decodedMessage);
+            }
+
+			if (result.decodedMessage != null
+                    && result.decodedMessage.contains("BasicSafetyMessage ::=")) {
+                logger.info("Applying BIT STRING decoding for BSM (Java layer)");
+                result.decodedMessage =
+                    BSMBitStringProcessor.processBSMBitStrings(result.decodedMessage);
             }
 
 

--- a/fedgov-cv-asn1decoder/src/main/java/gov/usdot/cv/asn1decoder/util/SPATBitStringProcessor.java
+++ b/fedgov-cv-asn1decoder/src/main/java/gov/usdot/cv/asn1decoder/util/SPATBitStringProcessor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package gov.usdot.cv.asn1decoder.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SPATBitStringProcessor {
+
+    /**
+     * IntersectionStatus bit names 
+     */
+    private static final String[] INTERSECTION_STATUS = {
+        "manualControlIsEnabled",          // 0
+        "stopTimeIsActivated",                         // 1
+        "failureFlash",              // 2
+        "preemptIsActive",                 // 3
+        "signalPriorityIsActive",             // 4
+        "fixedTimeOperation",                 // 5
+        "trafficDependentOperation",          // 6
+        "standbyOperation",             // 7
+        "failureMode",                     // 8
+        "off",                              // 9
+        "recentMAPmessageUpdate",          // 10
+        "recentChangeInMAPassignedLanesIDsUsed",  // 11
+        "noValidMAPisAvailableAtThisTime",  // 12
+        "noValidSPATisAvailableAtThisTime"  // 13
+    };
+    
+    private static final Map<String, String[]> FIELD_TO_NAMES = new HashMap<>();
+    static {
+        FIELD_TO_NAMES.put("status", INTERSECTION_STATUS);
+    };
+
+    private static final Pattern BIT_STRING_PATTERN = Pattern.compile(
+        "\\b(status)" +
+        ":\\s*([0-9A-Fa-f]{1,2}(?:\\s++[0-9A-Fa-f]{1,2})*+)\\s*"
+    );
+
+    public static String processSPATBitStrings(String decoded) {
+        if (decoded == null) return null;
+ 
+        Matcher m = BIT_STRING_PATTERN.matcher(decoded);
+        StringBuffer out = new StringBuffer();
+        while (m.find()) {
+            String fieldName = m.group(1);
+            String hex       = m.group(2).trim();
+            int unusedBits   = 0;
+            String[] names   = FIELD_TO_NAMES.get(fieldName);
+ 
+            if (names == null) {
+                // Regex said yes but dispatch table says no — leave unchanged.
+                m.appendReplacement(out, Matcher.quoteReplacement(m.group(0)));
+                continue;
+            }
+ 
+            String readable = BitStringUtil.decodeBitString(hex, unusedBits, names);
+            m.appendReplacement(out, Matcher.quoteReplacement(fieldName + ": " + readable));
+        }
+        m.appendTail(out);
+        return out.toString();
+    }
+ 
+ 
+    private SPATBitStringProcessor() { /* utility class */ }
+}   

--- a/fedgov-cv-asn1decoder/src/test/java/gov/usdot/cv/asn1decoder/BitStringProcessorTest.java
+++ b/fedgov-cv-asn1decoder/src/test/java/gov/usdot/cv/asn1decoder/BitStringProcessorTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 /**
  * Unit tests for the BIT STRING post-processors
- * ({@link MAPBitStringProcessor} and {@link BSMBitStringProcessor}).
+ * ({@link MAPBitStringProcessor}, {@link BSMBitStringProcessor}, {@link SPATBitStringProcessor}).
  *
  * Both processors are pure Java (regex + dispatch table + {@link BitStringUtil}),
  * so these tests run without the native asn1c library. Expected values are
@@ -295,5 +295,104 @@ public class BitStringProcessorTest {
         String input = "brakes: 80 (4 bits unused); lights: 80 (7 bits unused)";
         String expected = "brakes: 80 (4 bits unused); lights: { lowBeamHeadlightsOn }";
         Assert.assertEquals(expected, BSMBitStringProcessor.processBSMBitStrings(input));
+    }
+
+    // SPATBitStringProcessor
+
+    @Test
+    public void spatNullInputReturnsNull() {
+        Assert.assertNull(SPATBitStringProcessor.processSPATBitStrings(null));
+    }
+
+    @Test
+    public void spatEmptyStringReturnsEmptyString() {
+        Assert.assertEquals("", SPATBitStringProcessor.processSPATBitStrings(""));
+    }
+ 
+    @Test
+    public void unrecognizedFieldNameIsLeftUnchanged() {
+        // "revision" is not in the regex alternation, so it passes through verbatim.
+        String input = "revision: 80 00";
+        Assert.assertEquals(input, SPATBitStringProcessor.processSPATBitStrings(input));
+    }
+
+    @Test
+    public void statusSingleBit() {
+        // 0x80 0x00 -> bit 0 only.
+        Assert.assertEquals(
+            "status: { manualControlIsEnabled }",
+            SPATBitStringProcessor.processSPATBitStrings("status: 80 00"));
+    }
+ 
+    @Test
+    public void statusMultipleBitsFirstByte() {
+        // 0xA0 = 1010 0000 -> bits 0 and 2.
+        Assert.assertEquals(
+            "status: { manualControlIsEnabled failureFlash }",
+            SPATBitStringProcessor.processSPATBitStrings("status: A0 00"));
+    }
+ 
+    @Test
+    public void statusAllEightBitsOfFirstByte() {
+        // 0xFF 0x00 -> first 8 names (manualControlIsEnabled .. standbyOperation).
+        Assert.assertEquals(
+            "status: { manualControlIsEnabled stopTimeIsActivated failureFlash preemptIsActive "
+                + "signalPriorityIsActive fixedTimeOperation trafficDependentOperation "
+                + "standbyOperation }",
+            SPATBitStringProcessor.processSPATBitStrings("status: FF 00"));
+    }
+ 
+    @Test
+    public void statusAllFourteenNamedBits() {
+        // 14 named bits. "FF FC" = byte0 0xFF (bits 0-7),
+        // byte1 0xFC = 1111 1100 (bits 8-13 set, 14-15 reserved -> 2 unused).
+        Assert.assertEquals(
+            "status: { manualControlIsEnabled stopTimeIsActivated failureFlash preemptIsActive "
+                + "signalPriorityIsActive fixedTimeOperation trafficDependentOperation "
+                + "standbyOperation failureMode off recentMAPmessageUpdate "
+                + "recentChangeInMAPassignedLanesIDsUsed noValidMAPisAvailableAtThisTime "
+                + "noValidSPATisAvailableAtThisTime }",
+            SPATBitStringProcessor.processSPATBitStrings("status: FF FC"));
+    }
+ 
+    @Test
+    public void reservedBitsBeyondNamesAreIgnored() {
+        // "00 03" -> bits 14 and 15 set (reserved). 14 names cap the scan, so nothing emitted.
+        Assert.assertEquals(
+            "status: { }",
+            SPATBitStringProcessor.processSPATBitStrings("status: 00 03"));
+    }
+ 
+    @Test
+    public void noBitsSetProducesEmptyBraces() {
+        Assert.assertEquals(
+            "status: { }",
+            SPATBitStringProcessor.processSPATBitStrings("status: 00 00"));
+    }
+ 
+    @Test
+    public void lastNamedBitOnly() {
+        // bit 13 = noValidSPATisAvailableAtThisTime. byte1 = 0x04 = 0000 0100 -> bit 13.
+        Assert.assertEquals(
+            "status: { noValidSPATisAvailableAtThisTime }",
+            SPATBitStringProcessor.processSPATBitStrings("status: 00 04"));
+    }
+
+    @Test
+    public void lowercaseHexIsParsed() {
+        // Lowercase 'ff', byte0 set -> first 8 names.
+        Assert.assertEquals(
+            "status: { manualControlIsEnabled stopTimeIsActivated failureFlash preemptIsActive "
+                + "signalPriorityIsActive fixedTimeOperation trafficDependentOperation "
+                + "standbyOperation }",
+            SPATBitStringProcessor.processSPATBitStrings("status: ff 00"));
+    }
+ 
+    @Test
+    public void singularBitWordIsAccepted() {
+        // "1 bit unused" (singular) must match the same as "bits".
+        Assert.assertEquals(
+            "status: { manualControlIsEnabled }",
+            SPATBitStringProcessor.processSPATBitStrings("status: 80 00"));
     }
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Bit string decoding for SPAT messages were added in this PR, allowing for better readability after message decoding.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[CVCS-170](https://usdot-carma.atlassian.net/browse/CVCS-170?atlOrigin=eyJpIjoiZWM3NjA0MjVjZTllNDgwYThlZjZjZGIwNTAxOGYyOWYiLCJwIjoiaiJ9)

## Motivation and Context

Better decoding representation for bitstring representation in SPAT messages

## How Has This Been Tested?

Local deployment testing, unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[CVCS-170]: https://usdot-carma.atlassian.net/browse/CVCS-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ