### PR TITLE
HELPDESK-222: Preserve MAP elevation precision from ESRI API

### DIFF
--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/api.js
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/api.js
@@ -13,7 +13,7 @@ async function getElevation(dot, latlon, i, j, callback){
       if (elev == null || elev == undefined) {
         elev = -9999; // any sea value is set to -9999 by default. This brings it back to sea level as we know it
       } else {
-        elev = Math.round(elev);
+        elev = Math.round(elev * 100) / 100;
       }
       callback(elev, i, j, latlon, dot);
     } catch (error) {
@@ -30,7 +30,7 @@ async function getComputedElevation(latlon) {
         if (elev == null || elev === undefined) {
           elev = -9999;
         } else {
-          elev = Math.round(elev);
+          elev = Math.round(elev * 100) / 100;
         }
         resolve(elev);
       },
@@ -53,7 +53,7 @@ async function getElev(lat, lon) {
     if (elev == null || elev == undefined) {
       elev = -9999; //any sea value is set to -9999 by default. This brings it back to sea level as we know it
     } else {
-      elev = Math.round(elev);
+      elev = Math.round(elev * 100) / 100;
     }
     return elev;
   } catch (error) {

--- a/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/features.js
+++ b/fedgov-cv-ISDcreator-webapp/src/main/webapp/js/features.js
@@ -93,11 +93,17 @@ function onFeatureAdded(lanes, vectors, laneMarkers, laneWidths, isLoadMap){
 					// Compare the latitude and longitude from the existing lane values to see if the node moved
 					let latMatch = ((laneFeat.get("elevation")[j]?.latlon?.lat)?.toString()?.match(/^-?\d+(?:\.\d{0,11})?/)[0] == (latLon.lat).toString().match(/^-?\d+(?:\.\d{0,11})?/)[0]);
 					let lonMatch = ((laneFeat.get("elevation")[j]?.latlon?.lon)?.toString()?.match(/^-?\d+(?:\.\d{0,11})?/)[0] == (latLon.lon).toString().match(/^-?\d+(?:\.\d{0,11})?/)[0]);
-					// If the node elevation has never been edited or has moved along either axis, get a new elevation value
-					if (!laneFeat.get("elevation")[j]?.edited || !latMatch || !lonMatch){
-						getElevation(dot, latLon, i, j, function(elev, i, j, latLon, dot){
-							laneFeat.get("elevation")[j] = {'value': elev, 'edited': true, 'latlon': latLon};
-						});
+					// Retrieve a new elevation value if:
+					// 1) no elevation edit has been recorded for this node,
+					// 2) the node coordinates have changed, or
+					// 3) the stored elevation appears to be a legacy integer value from older MAP files
+					//    that lost decimal precision and should be recalculated from ESRI.
+					const storedElev = Number(laneFeat.get("elevation")[j]?.value);
+					if (!laneFeat.get("elevation")[j]?.edited || !latMatch || !lonMatch || Number.isInteger(storedElev)){
+							getElevation(dot, latLon, i, j, function(elev, i, j, latLon, dot){
+								laneFeat.get("elevation")[j] = {'value': elev, 'edited': true, 'latlon': latLon};
+								dot.set("elevation", laneFeat.get("elevation")[j]);
+							});
 					}
 				}
 				buildDots(i, j, dot, latLon, lanes, laneMarkers);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This change preserves elevation precision retrieved from the ESRI Elevation API by preventing elevation values from being rounded to whole meters before being stored and encoded.

Previously, elevation values returned from the ESRI service (e.g., 39.8 m, 39.9 m) were rounded using Math.round(elev), resulting in loss of sub-meter precision and causing elevation values to be encoded as whole meters.

The implementation now retains centimeter-level precision by rounding to two decimal places before storing the elevation value.

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
HELPDESK-222

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

During investigation of elevation encoding discrepancies, it was observed that elevation values displayed in the ISD Creator and encoded into messages did not match the original values returned by the ESRI Elevation service.

The issue was traced to the client-side elevation retrieval logic in api.js, where elevations were being rounded to integers:

elev = Math.round(elev);

This caused values such as:

39.8 → 40
39.3 → 39
40.7 → 41

As a result, encoded elevation values lost precision before entering the encoding pipeline.

The updated implementation preserves the decimal portion of the elevation value:

elev = Math.round(elev * 100) / 100;

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual verification performed using the MAP Creator application:

1. Added console logging to inspect raw elevation values returned by the ESRI Elevation API.
2. Confirmed API responses contained decimal precision (e.g., 39.8, 39.9, 40.7, 41.1).
3. Verified elevation values displayed in the Lane Configuration / Reference Point Configuration dialogs retained the expected decimal precision.
4. Generated and inspected encoded messages to confirm elevation values were no longer rounded to whole meters prior to encoding.
5. Executed project test suite using the standard build/test workflow and confirmed no test failures related to this change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
