### PR TITLE
Helpdesk 242: fix doubled elevation

### DIFF
--- a/fedgov-cv-TIMcreator-webapp/src/main/webapp/js/mapping.js
+++ b/fedgov-cv-TIMcreator-webapp/src/main/webapp/js/mapping.js
@@ -1628,6 +1628,9 @@ async function populateRefWindow(feature, lat, lon) {
     elev = await getElev(lat, lon);
     if (!feature.get("elevation")?.value) {
       $('#elev').val(elev);
+
+      // Store map elevation in feature properties
+      feature.set("elevation", elev);
     }
   }
 

--- a/fedgov-cv-TIMcreator-webapp/src/main/webapp/js/mapping.js
+++ b/fedgov-cv-TIMcreator-webapp/src/main/webapp/js/mapping.js
@@ -1307,6 +1307,7 @@ function onFeatureAdded() {
       const isLegacyRoundedElevation =
           hasElevation &&
           Number.isInteger(Number(elevation[j].value));
+      buildPolyDots(i, j, dot, latlon);
       if (!elevation[j]?.edited || !found || isLegacyRoundedElevation) {
         getElevation(dot, latlon, i, j, function (elev, i, j, latlon, dot) {
           const elevationObj = {
@@ -1316,8 +1317,6 @@ function onFeatureAdded() {
           };
       
           polygons.getSource().getFeatures()[i].get('elevation')[j] = elevationObj;
-      
-          buildPolyDots(i, j, dot, latlon);
         });
       }
     }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR addresses two issues in the TIM Creator application:

1. **Restore polygon node visibility after clicking the Done button**
   - Fixes the issue where polygon nodes were no longer displayed after loading a TIM message and hit the Done button.
This can be reporoduced after loading a new TIM file and hitting the Done button:
<img width="1920" height="1080" alt="HD242beforeDone" src="https://github.com/user-attachments/assets/a2ce4eec-349c-418b-961a-cbb4bb02ddcf" />
The result before the fix:
<img width="1920" height="1080" alt="HD242beofretheDonebuttonfix" src="https://github.com/user-attachments/assets/de0e7a8f-53e6-41ec-9ab7-ded3b899b2ef" />
After the fix:
<img width="1920" height="1080" alt="HD242afterDonefix" src="https://github.com/user-attachments/assets/154f80d8-f300-4c93-a9bb-401f4921afa8" />

2. **Fix verified point elevation encoding**
   - Fixes an issue where Verified Point Markers stored the surveyed elevation (`verifiedElev`) but did not preserve the map elevation (`elevation`).
   - Ensures the encoder receives both the verified surveyed elevation and the original map elevation.
   - Prevents incorrect elevation offset calculations during TIM encoding.
Example before the fix:
<img width="1920" height="1080" alt="HD242theelevationdoublevaluebeforethefix" src="https://github.com/user-attachments/assets/9352f2af-52b0-4ca3-bc6f-1d9069c159fd" />
The same encoding example with correct elevation value after the fix:
<img width="1920" height="1080" alt="HD242afterelevationencodingfix" src="https://github.com/user-attachments/assets/b6247ef9-e410-4225-ac9a-26025ead70ba" />


## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

HELPDESK-242

## Motivation and Context

The TIM Creator Verified Point Marker workflow was missing the map elevation value required for elevation offset calculation during TIM encoding.

Previously, Verified Point Markers only stored the surveyed elevation (`verifiedElev`). As a result, `verifiedMapElevation` was undefined (resulted in zero value) when the TIM was generated, causing incorrect elevation adjustments in the encoded TIM message.

Additionally, polygon nodes were not displayed after clicking the Done button, reducing usability when creating or editing polygon-based TIM elements.

These changes ensure:
- Correct elevation offset computation using both map and surveyed elevations.
- Improved polygon editing workflow after saving geometry.

## How Has This Been Tested?

The changes were tested locally using the TIM Creator application.

Testing performed:

- Created a Verified Point Marker and verified that:
  - The map elevation is stored in the feature properties.

- Verified the elevation encoding behavior:
  - Confirmed that the verified elevation offset is calculated correctly.
  - Confirmed that the previous elevation doubling/incorrect offset issue no longer occurs.

- Created polygon features and verified that:
  - Polygon nodes remain visible after clicking the Done button.
  - Polygon geometry can continue to be viewed and edited after saving.

Testing environment:
- Docker-based application environment
- Browser UI testing with TIM files

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
